### PR TITLE
Folgende Suchen sind jetzt möglich: value1 [value2 ...], fieldName1:value1 ...

### DIFF
--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/DataLoader.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/DataLoader.java
@@ -56,7 +56,7 @@ public class DataLoader implements ApplicationRunner {
         keeper.setFirstName("Hans");
         keeper.setLastName("Dampf");
         keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
-        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning, Features_.feeding)));
         keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
         keeper.setSalary(450L);
         keeper.setOid(UUID.randomUUID());
@@ -92,5 +92,95 @@ public class DataLoader implements ApplicationRunner {
         //Save all example Entities in an order that won't cause errors
         enclosureRepo.save(enclosure);
 
+        keeper.setFirstName("Berta");
+        keeper.setLastName("Bla");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(1250L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Carla");
+        keeper.setLastName("Cro");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(550L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Diana");
+        keeper.setLastName("Dom");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(1750L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Eleni");
+        keeper.setLastName("Ess");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(1200L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Frauke");
+        keeper.setLastName("Fur");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(2450L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Gerda");
+        keeper.setLastName("Gla");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(750L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Ilona");
+        keeper.setLastName("Ill");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(1250L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Karla");
+        keeper.setLastName("Kas");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(950L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Laura");
+        keeper.setLastName("Lob");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(2450L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
+
+        keeper.setFirstName("Micha");
+        keeper.setLastName("Mus");
+        keeper.setEmploymentDate(java.time.LocalDate.parse("01.01.2017", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSkill(new java.util.ArrayList<>(Arrays.asList(Features_.cleaning)));
+        keeper.setBirthday(java.time.LocalDate.parse("04.08.1974", java.time.format.DateTimeFormatter.ofPattern("dd.MM.yyyy")));
+        keeper.setSalary(1450L);
+        keeper.setOid(UUID.randomUUID());
+	keeperRepo.save(keeper);
     }
 }
+

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Enclosure_SearchController.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Enclosure_SearchController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.muenchen.service.QueryService;
+import de.muenchen.service.QueryServiceChanged;
 import de.muenchen.animad.admin.administration.service.gen.domain.Enclosure_;
 import de.muenchen.animad.admin.administration.service.rest.Enclosure_Repository;
 
@@ -36,7 +36,7 @@ import de.muenchen.animad.admin.administration.service.rest.Enclosure_Repository
 public class Enclosure_SearchController {
 		
     @Autowired
-    QueryService service;
+    QueryServiceChanged service;
 
     @Autowired
     Enclosure_Repository repository;
@@ -68,6 +68,37 @@ public class Enclosure_SearchController {
         final List<PersistentEntityResource> collect = enclosureStream.map(assembler::toResource).collect(Collectors.toList());
         return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
 	}
+
+    /* NEW START */
+    @RequestMapping(method = RequestMethod.GET, value ="findFullTextJunction")
+    @ResponseBody
+    public ResponseEntity<?> findFullTextJunction(PersistentEntityResourceAssembler assembler, @Param("q") String q){ if (q == null)
+        q = "";
+
+        List<String> annotatedFields = new ArrayList<>();
+        Class tmpClass = Enclosure_.class;
+        while (tmpClass != null) {
+            annotatedFields.addAll(Stream.of(tmpClass.getDeclaredFields())
+                    .filter(field -> field.isAnnotationPresent(org.hibernate.search.annotations.Field.class))
+                    .map(Field::getName)
+                    .collect(Collectors.toList()));
+            tmpClass = tmpClass.getSuperclass();
+        }
+
+
+
+        Stream<Enclosure_> enclosureStream;
+
+        try {
+            enclosureStream = service.queryJunction(q, Enclosure_.class, annotatedFields.toArray(new String[annotatedFields.size()])).stream();
+        } catch (EmptyQueryException e) {
+            enclosureStream = StreamSupport.stream(repository.findAll().spliterator(), false);
+        }
+
+        final List<PersistentEntityResource> collect = enclosureStream.map(assembler::toResource).collect(Collectors.toList());
+        return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
+    }
+    /* NEW END */
 }
 
 

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Keeper_SearchController.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Keeper_SearchController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import de.muenchen.service.QueryService;
+import de.muenchen.service.QueryServiceChanged;
 import de.muenchen.animad.admin.administration.service.gen.domain.Keeper_;
 import de.muenchen.animad.admin.administration.service.rest.Keeper_Repository;
 
@@ -36,7 +36,7 @@ import de.muenchen.animad.admin.administration.service.rest.Keeper_Repository;
 public class Keeper_SearchController {
 		
     @Autowired
-    QueryService service;
+    QueryServiceChanged service;
 
     @Autowired
     Keeper_Repository repository;
@@ -68,6 +68,35 @@ public class Keeper_SearchController {
         final List<PersistentEntityResource> collect = keeperStream.map(assembler::toResource).collect(Collectors.toList());
         return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
 	}
+
+	@RequestMapping(method = RequestMethod.GET, value ="findFullTextJunction")
+    @ResponseBody
+    public ResponseEntity<?> findFullTextJunction(PersistentEntityResourceAssembler assembler, @Param("q") String q){ if (q == null)
+            q = "";
+
+        List<String> annotatedFields = new ArrayList<>();
+        Class tmpClass = Keeper_.class;
+        while (tmpClass != null) {
+            annotatedFields.addAll(Stream.of(tmpClass.getDeclaredFields())
+                    .filter(field -> field.isAnnotationPresent(org.hibernate.search.annotations.Field.class))
+                    .map(Field::getName)
+                    .collect(Collectors.toList()));
+            tmpClass = tmpClass.getSuperclass();
+        }
+
+
+
+        Stream<Keeper_> keeperStream;
+
+        try {
+            keeperStream = service.queryGitLike(q, Keeper_.class, annotatedFields.toArray(new String[annotatedFields.size()])).stream();
+        } catch (EmptyQueryException e) {
+            keeperStream = StreamSupport.stream(repository.findAll().spliterator(), false);
+        }
+
+        final List<PersistentEntityResource> collect = keeperStream.map(assembler::toResource).collect(Collectors.toList());
+        return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
+    }
 }
 
 

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Keeper_SearchController.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/animad/admin/administration/service/gen/rest/search/Keeper_SearchController.java
@@ -69,6 +69,7 @@ public class Keeper_SearchController {
         return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
 	}
 
+	/* NEW START */
 	@RequestMapping(method = RequestMethod.GET, value ="findFullTextJunction")
     @ResponseBody
     public ResponseEntity<?> findFullTextJunction(PersistentEntityResourceAssembler assembler, @Param("q") String q){ if (q == null)
@@ -89,7 +90,7 @@ public class Keeper_SearchController {
         Stream<Keeper_> keeperStream;
 
         try {
-            keeperStream = service.queryGitLike(q, Keeper_.class, annotatedFields.toArray(new String[annotatedFields.size()])).stream();
+            keeperStream = service.queryJunction(q, Keeper_.class, annotatedFields.toArray(new String[annotatedFields.size()])).stream();
         } catch (EmptyQueryException e) {
             keeperStream = StreamSupport.stream(repository.findAll().spliterator(), false);
         }
@@ -97,6 +98,7 @@ public class Keeper_SearchController {
         final List<PersistentEntityResource> collect = keeperStream.map(assembler::toResource).collect(Collectors.toList());
         return new ResponseEntity<Object>(new Resources<>(collect), HttpStatus.OK);
     }
+    /* NEW END */
 }
 
 

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/QueryServiceChanged.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/QueryServiceChanged.java
@@ -1,0 +1,75 @@
+
+package de.muenchen.service;
+
+import java.util.*;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.FullTextQuery;
+import org.hibernate.search.jpa.Search;
+import org.hibernate.search.query.dsl.BooleanJunction;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Transactional
+public class QueryServiceChanged {
+    @PersistenceContext
+    EntityManager entityManager;
+
+    public QueryServiceChanged() {
+    }
+
+    public <E extends BaseEntity> List<E> query(String text, Class<E> entity, String[] properties) {
+        FullTextEntityManager fullTextEntityManager = Search.getFullTextEntityManager(this.entityManager);
+        QueryBuilder queryBuilder = fullTextEntityManager.getSearchFactory().buildQueryBuilder().forEntity(entity).get();
+        Query query = queryBuilder.keyword().fuzzy().onFields(properties).matching(text).createQuery();
+        FullTextQuery jpaQuery = fullTextEntityManager.createFullTextQuery(query, new Class[]{entity});
+        return jpaQuery.getResultList();
+    }
+
+    public <E extends BaseEntity> List<E> queryGitLike(String text, Class<E> entity, String[] properties) {
+        FullTextEntityManager fullTextEntityManager = Search.getFullTextEntityManager(this.entityManager);
+        QueryBuilder queryBuilder = fullTextEntityManager.getSearchFactory().buildQueryBuilder().forEntity(entity).get();
+
+        List<String> props = new ArrayList<>();
+        String[] queries;
+
+        Query query = null;
+        BooleanJunction boolJunction = queryBuilder.bool();
+
+        // Loop over all queries and join them together
+        queries = text.split(" ");
+        for (int i = 0; i < queries.length; i++) {
+            query = createSingleQuery(queries[i], queryBuilder, properties);
+            boolJunction = boolJunction.must(query);
+        }
+
+        query = boolJunction.createQuery();
+        FullTextQuery jpaQuery = fullTextEntityManager.createFullTextQuery(query, new Class[]{entity});
+        return jpaQuery.getResultList();
+    }
+
+    private Query createSingleQuery(String text, QueryBuilder queryBuilder, String[] properties) {
+        Query query;
+        String[] termValues;
+
+        if (text.contains(":")) {
+            // if query equals to fieldName:value use Term to search
+            termValues = text.split(":");
+            query = new TermQuery(new Term(termValues[0], termValues[1]));
+        }
+        else {
+            // Otherwise search in all fields
+            query = queryBuilder.keyword().onFields(properties).matching(text).createQuery();
+        }
+
+        return query;
+    }
+
+}

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/QueryServiceChanged.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/QueryServiceChanged.java
@@ -33,7 +33,8 @@ public class QueryServiceChanged {
         return jpaQuery.getResultList();
     }
 
-    public <E extends BaseEntity> List<E> queryGitLike(String text, Class<E> entity, String[] properties) {
+    /* NEW START must be added to existing QueryService*/
+    public <E extends BaseEntity> List<E> queryJunction(String text, Class<E> entity, String[] properties) {
         FullTextEntityManager fullTextEntityManager = Search.getFullTextEntityManager(this.entityManager);
         QueryBuilder queryBuilder = fullTextEntityManager.getSearchFactory().buildQueryBuilder().forEntity(entity).get();
 
@@ -71,5 +72,6 @@ public class QueryServiceChanged {
 
         return query;
     }
+    /* NEW END */
 
 }

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/SearchResourcesProcessorChanged.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/SearchResourcesProcessorChanged.java
@@ -1,0 +1,24 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by Fernflower decompiler)
+//
+
+package de.muenchen.service;
+
+import org.springframework.data.rest.webmvc.RepositorySearchesResource;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SearchResourcesProcessorChanged implements ResourceProcessor<RepositorySearchesResource> {
+    public SearchResourcesProcessorChanged() {
+    }
+
+    public RepositorySearchesResource process(RepositorySearchesResource repositorySearchesResource) {
+        String search = repositorySearchesResource.getId().getHref();
+        Link findFullTextLucene = (new Link(search + "/findFullTextJunction{?q}")).withRel("findFullTextJunction");
+        repositorySearchesResource.add(findFullTextLucene);
+        return repositorySearchesResource;
+    }
+}

--- a/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/SearchResourcesProcessorChanged.java
+++ b/animad-service-administration/animad-administration-service/src/main/java/de/muenchen/service/SearchResourcesProcessorChanged.java
@@ -17,8 +17,11 @@ public class SearchResourcesProcessorChanged implements ResourceProcessor<Reposi
 
     public RepositorySearchesResource process(RepositorySearchesResource repositorySearchesResource) {
         String search = repositorySearchesResource.getId().getHref();
+        /* NEW START - must be added to existing RepositorySearchesResource*/
         Link findFullTextLucene = (new Link(search + "/findFullTextJunction{?q}")).withRel("findFullTextJunction");
         repositorySearchesResource.add(findFullTextLucene);
+        /* NEW END */
+
         return repositorySearchesResource;
     }
 }


### PR DESCRIPTION
 [fieldName2:value2 ...] und Kombinationen daraus

Da ich kein Repository für Service-Lib gefunden habe, gibt es im Moment ein package
de.muenchen.service unter dem die Klassen QueryServiceChanged und SearchResourcesProcessorChanged liegen. Dies müssen eigentlich in die Programmierung für Service-Lib rein (Klassen de.muenchen.service.QueryService und SearchResourcesProcessor)